### PR TITLE
Added support for multiple generic interfaces on a single class.

### DIFF
--- a/src/NanoIoC.Tests/MultipleGenericInterfacesImpelemtedOnSameClass.cs
+++ b/src/NanoIoC.Tests/MultipleGenericInterfacesImpelemtedOnSameClass.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace NanoIoC.Tests
+{
+	[TestFixture]
+	public class MultipleGenericInterfacesImpelemtedOnSameClass
+	{
+		public interface IMsg { }
+
+		public interface IMsgHandler<T>
+			where T : IMsg
+		{
+		}
+
+		public class FooMsg : IMsg { }
+		public class BahMsg : IMsg  { }
+
+		public class MsgHandler :
+			IMsgHandler<FooMsg>,
+			IMsgHandler<BahMsg>
+		{
+			public MsgHandler()
+			{
+			}
+		}
+
+		public class MsgHandlerTypeProcessor : OpenGenericTypeProcessor
+		{
+			protected override Type OpenGenericTypeToClose
+			{
+				get { return typeof(IMsgHandler<>); }
+			}
+
+			public override Lifecycle Lifecycle
+			{
+				get { return Lifecycle.Singleton; }
+			}
+		}
+
+		[Test]
+		public void Can_locate_mutltiple_generic_interfaces_on_same_class()
+		{
+			var container = new Container();
+			container.RunAllTypeProcessors();
+
+			var fooHandler = container.Resolve<IMsgHandler<FooMsg>>();
+			Assert.That(fooHandler, Is.Not.Null, "foo handler");
+
+			var bahHandler = container.Resolve<IMsgHandler<BahMsg>>();
+			Assert.That(bahHandler, Is.Not.Null, "bah handler");
+		}
+
+		[Test]
+		[Ignore("Deliberately added a test I know will fail, to resolve at some time in the future as it would be a more significant restructure.")]
+		public void Singleton_instance_is_created_per_concrete_class_not_per_interface_implementation()
+		{
+			var container = new Container();
+			container.RunAllTypeProcessors();
+
+			// Not a test, but an assertion of state we rely on.
+			Assert.That(new MsgHandlerTypeProcessor().Lifecycle, Is.EqualTo(Lifecycle.Singleton));
+
+			var fooHandler = container.Resolve<IMsgHandler<FooMsg>>();
+			var bahHandler = container.Resolve<IMsgHandler<BahMsg>>();
+
+			Assert.That(fooHandler, Is.SameAs(bahHandler));
+		}
+	}
+}

--- a/src/NanoIoC.Tests/NanoIoC.Tests.csproj
+++ b/src/NanoIoC.Tests/NanoIoC.Tests.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="ConstructionException.cs" />
     <Compile Include="DependencyStore.cs" />
+    <Compile Include="MultipleGenericInterfacesImpelemtedOnSameClass.cs" />
     <Compile Include="MultipleRegistrationsError.cs" />
     <Compile Include="SlowCtor.cs" />
     <Compile Include="RemovingInstances.cs" />

--- a/src/NanoIoC/OpenGenericTypeProcessor.cs
+++ b/src/NanoIoC/OpenGenericTypeProcessor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NanoIoC
 {
@@ -16,11 +18,22 @@ namespace NanoIoC
 			if (type.IsInterface || type.IsAbstract)
 				return;
 
-			var typeArguments = type.GetGenericArgumentsClosing(this.OpenGenericTypeToClose);
+			foreach (var itype in OpenGenericTypeInterfacesFor(type))
+			{
+				var typeArguments = itype.GetGenericArguments();
 
-			var closedType = this.OpenGenericTypeToClose.MakeGenericType(typeArguments);
+				var closedType = this.OpenGenericTypeToClose.MakeGenericType(typeArguments);
 
-			container.Register(closedType, type, this.Lifecycle);
+				container.Register(closedType, type, this.Lifecycle);
+			}
+
+		}
+
+		private IEnumerable<Type> OpenGenericTypeInterfacesFor(Type type)
+		{
+			return type.GetInterfaces()
+			           .Where(t => t.IsGenericType &&
+			                       t.GetGenericTypeDefinition() == this.OpenGenericTypeToClose);
 		}
 	}
 }


### PR DESCRIPTION
Nano doesn't currently support classes that implement the same generic interface multiple times.  Handy for grouping common behaviour onto a single class (e.g. CQRS view handlers)

e.g. StudentLookupView : IEventHandler<StudentCreated>, IEventHandler<StudentNameChanged>, IEventHandler<StudentDeleted> ...
