### PR TITLE
Adds ExecutionContext Lifecycle

### DIFF
--- a/src/NanoIoC.Tests/ExecutionContextScopeAcrossThreads.cs
+++ b/src/NanoIoC.Tests/ExecutionContextScopeAcrossThreads.cs
@@ -1,0 +1,53 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NanoIoC.Tests
+{
+    [TestFixture]
+    public class ExecutionContextScopeAcrossThreads
+	{
+        [Test]
+        public void ShouldConstruct()
+        {
+            var container = new Container();
+			container.Register<TestInterface, TestClass>(Lifecycle.ExecutionContextLocal);
+
+
+	        TestInterface instance = null;
+
+	        Task.Run(() => instance = container.Resolve<TestInterface>()).Wait();
+
+			Assert.IsNotNull(instance);
+			Assert.IsInstanceOf<TestClass>(instance);
+        }
+
+		[Test]
+		public void ShouldAlwaysBeTheSameInstance()
+		{
+			var container = new Container();
+			container.Register<TestInterface, TestClass>();
+
+			TestInterface instance = null;
+			TestInterface instance2 = null;
+
+			Task.Run(() =>
+			{
+				instance = container.Resolve<TestInterface>();
+				instance2 = container.Resolve<TestInterface>();
+			}).Wait();
+
+			Assert.IsNotNull(instance);
+			Assert.AreSame(instance, instance2);
+		}
+
+    	public class TestClass : TestInterface
+        {
+            
+        }
+
+		public interface TestInterface
+		{
+			
+		}
+    }
+}

--- a/src/NanoIoC.Tests/NanoIoC.Tests.csproj
+++ b/src/NanoIoC.Tests/NanoIoC.Tests.csproj
@@ -46,6 +46,8 @@
     <Compile Include="DependencyStore.cs" />
     <Compile Include="MultipleGenericInterfacesImpelemtedOnSameClass.cs" />
     <Compile Include="MultipleRegistrationsError.cs" />
+    <Compile Include="ExecutionContextScopeAcrossThreads.cs" />
+    <Compile Include="RegisteredConcreteTypesWithExecutionContextScope.cs" />
     <Compile Include="SlowCtor.cs" />
     <Compile Include="RemovingInstances.cs" />
     <Compile Include="With.cs" />

--- a/src/NanoIoC.Tests/NanoIoC.Tests.csproj
+++ b/src/NanoIoC.Tests/NanoIoC.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NanoIoC.Tests</RootNamespace>
     <AssemblyName>NanoIoC.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">

--- a/src/NanoIoC.Tests/RegisteredConcreteTypesWithExecutionContextScope.cs
+++ b/src/NanoIoC.Tests/RegisteredConcreteTypesWithExecutionContextScope.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+
+namespace NanoIoC.Tests
+{
+    [TestFixture]
+    public class RegisteredConcreteTypesWithExecutionContextScope
+    {
+        [Test]
+        public void ShouldConstruct()
+        {
+            var container = new Container();
+			container.Register<TestInterface, TestClass>(Lifecycle.ExecutionContextLocal);
+
+			var instance = container.Resolve<TestInterface>();
+            Assert.IsInstanceOf<TestClass>(instance);
+        }
+
+		[Test]
+		public void ShouldAlwaysBeTheSameInstance()
+		{
+			var container = new Container();
+			container.Register<TestInterface, TestClass>();
+
+			var instance = container.Resolve<TestInterface>();
+			var instance2 = container.Resolve<TestInterface>();
+			Assert.AreSame(instance, instance2);
+		}
+
+    	public class TestClass : TestInterface
+        {
+            
+        }
+
+		public interface TestInterface
+		{
+			
+		}
+    }
+}

--- a/src/NanoIoC.Tests/RemovingRegistrations.cs
+++ b/src/NanoIoC.Tests/RemovingRegistrations.cs
@@ -66,6 +66,23 @@ namespace NanoIoC.Tests
 			Assert.AreSame(class2, classA1);
 		}
 
+		[Test]
+		public void ShouldRemoveInstances4()
+		{
+			var container = new Container();
+			var class1 = new ClassA1();
+			var class2 = new ClassA1();
+
+			container.Inject(class1, Lifecycle.ExecutionContextLocal);
+
+			container.RemoveAllInstancesWithLifecycle(Lifecycle.ExecutionContextLocal);
+
+			container.Inject(class2, Lifecycle.ExecutionContextLocal);
+
+			var classA1 = container.Resolve<ClassA1>();
+			Assert.AreSame(class2, classA1);
+		}
+
 		public interface InterfaceA
 		{
 			

--- a/src/NanoIoC/ExecutionContextInstanceStore.cs
+++ b/src/NanoIoC/ExecutionContextInstanceStore.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Web;
 
 namespace NanoIoC
 {

--- a/src/NanoIoC/ExecutionContextInstanceStore.cs
+++ b/src/NanoIoC/ExecutionContextInstanceStore.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Web;
+
+namespace NanoIoC
+{
+	/// <summary>
+	/// Stores instances in the current ExecutionContext
+	/// </summary>
+	sealed class ExecutionContextInstanceStore : InstanceStore
+	{
+		readonly AsyncLocal<IDictionary<Type, IList<Tuple<Registration, object>>>> threadStore;
+		readonly AsyncLocal<IDictionary<Type, IList<Registration>>> injectedRegistrations;
+
+		public ExecutionContextInstanceStore()
+		{
+			this.threadStore = new AsyncLocal<IDictionary<Type, IList<Tuple<Registration, object>>>>
+			{
+				Value = new Dictionary<Type, IList<Tuple<Registration, object>>>()
+			};
+			this.injectedRegistrations = new AsyncLocal<IDictionary<Type, IList<Registration>>>
+			{
+				Value = new Dictionary<Type, IList<Registration>>()
+			};
+		}
+
+		public ExecutionContextInstanceStore(IInstanceStore instanceStore) : this()
+		{
+			if (!(instanceStore is ExecutionContextInstanceStore))
+				throw new ArgumentException("executionContextInstanceStore is not a `" + typeof(ExecutionContextInstanceStore).FullName + "`");
+
+			var executionContextInstanceStore = instanceStore as ExecutionContextInstanceStore;
+
+			this.threadStore.Value = new Dictionary<Type, IList<Tuple<Registration, object>>>(executionContextInstanceStore.threadStore.Value);
+			this.injectedRegistrations.Value = new Dictionary<Type, IList<Registration>>(executionContextInstanceStore.injectedRegistrations.Value);
+		}
+
+		public override IDictionary<Type, IList<Tuple<Registration, object>>> Store
+		{
+			get
+			{
+				if (this.threadStore.Value == null)
+					this.threadStore.Value = new Dictionary<Type, IList<Tuple<Registration, object>>>();
+
+				return this.threadStore.Value;
+			}
+		}
+
+		public override IDictionary<Type, IList<Registration>> InjectedRegistrations
+		{
+			get
+			{
+				if (this.injectedRegistrations.Value == null)
+					this.injectedRegistrations.Value = new Dictionary<Type, IList<Registration>>();
+
+				return this.injectedRegistrations.Value;
+			}
+		}
+
+		protected override Lifecycle Lifecycle => Lifecycle.ExecutionContextLocal;
+	}
+}

--- a/src/NanoIoC/Lifecycle.cs
+++ b/src/NanoIoC/Lifecycle.cs
@@ -4,6 +4,7 @@ namespace NanoIoC
     {
 		Transient = 1,
 		HttpContextOrThreadLocal = 2,
-        Singleton = 3
+        Singleton = 3,
+		ExecutionContextLocal = 4,
     }
 }

--- a/src/NanoIoC/NanoIoC.csproj
+++ b/src/NanoIoC/NanoIoC.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Container.cs" />
     <Compile Include="ContainerException.cs" />
     <Compile Include="ContainerExtensions.cs" />
+    <Compile Include="ExecutionContextInstanceStore.cs" />
     <Compile Include="InjectionBehaviour.cs" />
     <Compile Include="OpenGenericTypeProcessor.cs" />
     <Compile Include="InstanceStore.cs" />

--- a/src/NanoIoC/NanoIoC.csproj
+++ b/src/NanoIoC/NanoIoC.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NanoIoC</RootNamespace>
     <AssemblyName>NanoIoC</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Similar to the `HttpContextOrThreadLocalStore`, but uses `AsyncLocal<T>` instead of `ThreadLocal<T>`.

`ThreadLocal` causes pain when combined with async code, since the concept of threads is abstracted away and you may or may not be on the same thread on either side of a continuation.

Will hopefully serve the same purpose and obsolete the `HttpContextOrThreadLocal` lifecycle.
