### PR TITLE
Added unmanaged dll check when loading assemblies.

### DIFF
--- a/src/NanoIoC/Assemblies.cs
+++ b/src/NanoIoC/Assemblies.cs
@@ -39,12 +39,16 @@ namespace NanoIoC
 				{
 					assembly = Assembly.LoadFrom(assemblyPath);
 				}
-				catch(Exception e)
+				catch (BadImageFormatException)
+				{
+					
+				}
+				catch (Exception e)
 				{
 					Console.WriteLine("==============================");
 					Console.WriteLine(e.Message);
 					Console.WriteLine("==============================");
-					
+
 					throw e;
 				}
 


### PR DESCRIPTION
The error was to do with trying to load unmanaged dlls. This fix will check for this specific error and skip past them as we don't care about trying to load these in.